### PR TITLE
Fix for missing icon in recent Home Assistant releases

### DIFF
--- a/love-lock-card.js
+++ b/love-lock-card.js
@@ -99,7 +99,7 @@ class LoveLockCard extends HTMLElement {
     }
 
     // Lock Icon
-    const lockicon = document.createElement("iron-icon");
+    const lockicon = document.createElement("ha-icon");
     lockicon.setAttribute("icon", "mdi:lock-outline");
     lockicon.setAttribute("style", "position:absolute; top: 10px; right:7px;");
     cover.appendChild(lockicon);


### PR DESCRIPTION
Fix for issue #6, per @Cycloid0's comment; makes the lock icon work again on Home Assistant post 0.110.2.
